### PR TITLE
nxp_gpio: fix incorrect GPDAT register offset for set_gpio_bit

### DIFF
--- a/drivers/nxp/gpio/nxp_gpio.c
+++ b/drivers/nxp/gpio/nxp_gpio.c
@@ -30,7 +30,7 @@ int set_gpio_bit(uint32_t *gpio_base_addr,
 	}
 
 	gpdir = gpio_base_addr + GPDIR_REG_OFFSET;
-	gpdat = gpio_base_addr + (GPDAT_REG_OFFSET >> 2);
+	gpdat = gpio_base_addr + GPDAT_REG_OFFSET;
 
 	/*
 	 * Set the corresponding bit in direction register


### PR DESCRIPTION
This commit corrects the GPDAT register offset for the NXP GPIO driver. According to specifications (for example, LS1043ARM), the register is located at the 0x8 offset (for example, see 24.5.4.1). This offset is already defined by GPDAT_REG_OFFSET symbol, making the shift operation a bug.